### PR TITLE
fix: Fixed logos paths in login and signup components

### DIFF
--- a/packages/ui/src/components/login-signup-dark/Login-UI-dark.tsx
+++ b/packages/ui/src/components/login-signup-dark/Login-UI-dark.tsx
@@ -1,7 +1,7 @@
 import './Login-UI-dark.css';
 import { Component, createSignal, onMount, Show } from 'solid-js';
-import googleLogo from '/google.png';
-import hideLogo from '/hide.png';
+import googleLogo from '../../../public/google.png';
+import hideLogo from '../../../public/hide.png';
 
 export const LoginFormDark: Component = () => {
   const [loginStatus, setLoginStatus] = createSignal(null);

--- a/packages/ui/src/components/login-signup-dark/Sign-up-dark.tsx
+++ b/packages/ui/src/components/login-signup-dark/Sign-up-dark.tsx
@@ -1,8 +1,8 @@
 import './Sign-up-dark.css';
 import { Component, createSignal, onMount, Show } from 'solid-js';
-import googleLogo from '/google.png';
-import hideLogo from '/hide.png';
-import { useNavigate } from '@solidjs/router';
+import googleLogo from '../../../public/google.png';
+import hideLogo from '../../../public/hide.png';
+
 
 export const SignUpFormDark: Component = () => {
   const [loginStatus, setLoginStatus] = createSignal(null);

--- a/packages/ui/src/components/login-signup-light/Login-UI-light.tsx
+++ b/packages/ui/src/components/login-signup-light/Login-UI-light.tsx
@@ -1,7 +1,7 @@
 import './Login-UI-light.css';
 import { Component, createSignal, Show, onMount } from 'solid-js';
-import googleLogo from '/google.png';
-import hideLogo from '/hide.png';
+import googleLogo from '../../../public/google.png';
+import hideLogo from '../../../public/hide.png';
 
 export const LoginFormLight: Component = () => {
   const [loginStatus, setLoginStatus] = createSignal(null);

--- a/packages/ui/src/components/login-signup-light/Sign-up-light.tsx
+++ b/packages/ui/src/components/login-signup-light/Sign-up-light.tsx
@@ -1,7 +1,7 @@
 import './Sign-up-light.css';
 import { Component, createSignal, onMount, Show } from 'solid-js';
-import googleLogo from '/google.png';
-import hideLogo from '/hide.png';
+import googleLogo from '../../../public/google.png';
+import hideLogo from '../../../public/hide.png';
 
 export const SignUpFormLight: Component = () => {
   const [loginStatus, setLoginStatus] = createSignal(null);

--- a/packages/ui/src/components/login-signup-light/Sign-up-light.tsx
+++ b/packages/ui/src/components/login-signup-light/Sign-up-light.tsx
@@ -9,7 +9,7 @@ export const SignUpFormLight: Component = () => {
     usernameInput: '',
     passwordInput: '',
   });
-
+ 
   const [isClient, setIsClient] = createSignal(false);
 
   onMount(() => {


### PR DESCRIPTION

## Description

Logos were not rendering for either component (login and sign up). Updated import paths of logos.



## Checklist


- [x ] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [ ] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [x ] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)
